### PR TITLE
Checking if the distribution already has the zfs-auto-snapshot before installing from PPA

### DIFF
--- a/tasks/ubuntu.yml
+++ b/tasks/ubuntu.yml
@@ -105,11 +105,20 @@
   notify:
     - start zfs-share
 
+- name: ubuntu | Checking for ZFS-Auto-Snapshot package from the distribution
+  command: apt-cache show zfs-auto-snapshot
+  ignore_errors: true
+  register: auto_snapshot
+  when: zfs_enable_auto_snapshots
+
 - name: ubuntu | Adding ZFS-Auto-Snapshot Repo
   apt_repository:
     repo: ppa:bob-ziuchkovski/zfs-auto-snapshot
     state: present
-  when: zfs_enable_auto_snapshots
+  when: >
+    zfs_enable_auto_snapshots and
+    auto_snapshot.rc != 0 and
+    auto_snapshot.stderr == 'E: No packages found'
 
 - name: ubuntu | Installing ZFS-Auto-Snapshot
   apt:

--- a/tasks/ubuntu.yml
+++ b/tasks/ubuntu.yml
@@ -110,6 +110,9 @@
   ignore_errors: true
   register: auto_snapshot
   when: zfs_enable_auto_snapshots
+  changed_when: false
+  failed_when: false
+  check_mode: false
 
 - name: ubuntu | Adding ZFS-Auto-Snapshot Repo
   apt_repository:
@@ -117,7 +120,6 @@
     state: present
   when: >
     zfs_enable_auto_snapshots and
-    auto_snapshot.rc != 0 and
     auto_snapshot.stderr == 'E: No packages found'
 
 - name: ubuntu | Installing ZFS-Auto-Snapshot


### PR DESCRIPTION
Checking if the distribution already has the zfs-auto-snapshot before installing from PPA.

Ubuntu 18 or above already has this package. Check out https://packages.ubuntu.com/search?keywords=zfs-auto-snapshot&searchon=names&suite=all&section=all

Hope this PR helpful to you guys! Thank you!