### PR TITLE
Extract Ubuntu universe URL to a variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,9 @@ zfs_create_filesystems: false
 # Defines if ZFS pool(s) are created
 zfs_create_pools: false
 
+# Defines the default Ubuntu universe repo
+zfs_ubuntu_universe_repo_url: http://us.archive.ubuntu.com/ubuntu
+
 # Defines if ZFS volumes(s) are created
 zfs_create_volumes: false
 zfs_debian_package_key: http://zfsonlinux.org/4D5843EA.asc

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,6 +7,9 @@ zfs_create_filesystems: false
 # Defines if ZFS pool(s) are created
 zfs_create_pools: false
 
+# Defines the default Ubuntu universe repo
+zfs_ubuntu_universe_repo_url: http://us.archive.ubuntu.com/ubuntu
+
 # Defines if ZFS volumes(s) are created
 zfs_create_volumes: false
 zfs_debian_package_key: http://zfsonlinux.org/4D5843EA.asc

--- a/tasks/ubuntu.yml
+++ b/tasks/ubuntu.yml
@@ -15,7 +15,7 @@
 
 - name: ubuntu | ensuring Ubuntu universe repo is enabled ({{ ansible_distribution_version }} >= 16.04)
   apt_repository:
-    repo: "deb http://us.archive.ubuntu.com/ubuntu {{ ansible_distribution_release|lower }} universe"
+    repo: "deb {{ zfs_ubuntu_universe_repo_url }} {{ ansible_distribution_release|lower }} universe"
     state: present
   when: >
         ansible_distribution_version >= '16.04'


### PR DESCRIPTION
Hey there!
Thanks for the great playbook! It works great on my RPi-based server with one exception.
Ubuntu Server for Raspberry Pis uses a different universe repo URL (http://ports.ubuntu.com/ubuntu-ports).
This commit extracts the default URL to a variable, which allows replacing the URL when using Ubuntu Server on RPis.