### PR TITLE
Don't run iscsi-handler if iscsi is disabled

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,6 +4,9 @@
   service:
     name: "iscsitarget"
     state: restarted
+  when: >
+        zfs_enable_iscsi is defined and
+        zfs_enable_iscsi
 
 - name: restart nfs-kernel-server
   service:


### PR DESCRIPTION
Don't run iscsi-handler if iscsi is disabled

## Description
https://github.com/mrlesmithjr/ansible-zfs/blob/69c45f61ca5b8097543a12c2f40bef5a10b1003b/defaults/main.yml#L19

Wenn `zfs_volumes` are defined but `zfs_enable_iscsi: false` it still run's the handler - and fails if iscsi is not installed at all on target host.
