### PR TITLE
fix for looking up existing devices

### DIFF
--- a/tasks/manage_zfs.yml
+++ b/tasks/manage_zfs.yml
@@ -34,7 +34,7 @@
         zfs_create_pools and
         (item.type == "basic" and
         item.state == "present") and
-        item.devices[0] not in zpool_devices.stdout and
+        (item.devices[0]|basename) not in zpool_devices.stdout and
         item.action|lower == "add" and
         (zpool_created.changed or item.name in zpools.stdout)
 
@@ -59,7 +59,7 @@
         zfs_create_pools and
         (item.type != "basic" and
         item.state == "present") and
-        item.devices[0] not in zpool_devices.stdout and
+        (item.devices[0]|basename) not in zpool_devices.stdout and
         item.action|lower == "add" and
         (zpool_created.changed or item.name in zpools.stdout)
 


### PR DESCRIPTION
defining pools with additional log/cache devices leads to errors on second run:

`invalid vdev specification", "use '-f' to override the following errors:`

while adding a device role checks for existing device in command stdout from `zpool status`. 

`zpool status` lists devices without full path. Only last basename is showed. So the following  

  `item.devices[0] not in zpool_devices.stdout and`

is always true and it's tried to add already existent devices again:

```
- name: manage_zfs | adding mirror/zraid zpool(s)
  command: "zpool add {{ item.options | join (' ') if item.options is defined else '' }} {{ item.name }} {{ item.type }} {{ item.devices|join (' ') }}"
  with_items: "{{ zfs_pools }}"
  when: >
        zfs_pools is defined and
        zfs_create_pools and
        (item.type != "basic" and
        item.state == "present") and
        item.devices[0] not in zpool_devices.stdout and
        item.action|lower == "add" and
        (zpool_created.changed or item.name in zpools.stdout)
```