### PR TITLE
fix for debian buster and newer

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,6 +7,16 @@ zfs_create_filesystems: false
 # Defines if ZFS pool(s) are created
 zfs_create_pools: false
 
+# Overwrite debian release
+# debian_release: 
+debian_use_backports: True
+
+# Defines Debian Backports Repo
+backports_internal_uri: https://deb.debian.org/debian
+backports_internal_components: "main contrib non-free"
+backports_internal_additional_packages:
+  - apt-transport-https
+
 # Defines if ZFS volumes(s) are created
 zfs_create_volumes: false
 zfs_debian_package_key: http://zfsonlinux.org/4D5843EA.asc

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -1,56 +1,60 @@
 ---
+
+- set_fact:
+    default_debian_distribution: "{{ ansible_distribution_release }}"
+  when: default_debian_distribution is not defined
+
 - name: debian | installing pre-reqs
   apt:
     name:
       - lsb-release
     state: present
 
-- name: debian | adding zfs repo key
-  apt_key:
-    url: "{{ zfs_debian_package_key }}"
-    state: present
-
-- name: debian | downloading zfs package
-  get_url:
-    url: "{{ zfs_debian_package_url }}/{{ zfs_debian_package }}"
-    dest: "/opt/{{ zfs_debian_package }}"
-
-- name: debian | installing zfs package
+- name: debian | install additional packages
   apt:
-    deb: "/opt/{{ zfs_debian_package }}"
+    pkg: "{{ backports_internal_additional_packages }}"
     state: present
-  register: zfs_package_installed
+  when: backports_internal_additional_packages | length > 0
 
-- name: debian | updating apt-cache
-  apt:
-    update_cache: true
-  when: zfs_package_installed.changed
+- name: debian | add backports repository
+  block:
+    - name: set debian release
+      apt_repository:
+        repo: deb {{ backports_internal_uri }} {{ ansible_distribution_release }}-backports {{ backports_internal_components }}
+        state: present
+        update_cache: yes
+    - name: set backports
+      set_fact: 
+        debian_release: '{{ default_debian_distribution + "-backports" }}'
+  when: debian_use_backports
 
-- name: debian | installing zfs
-  apt:
-    name: debian-zfs
+- name: debian | install zfs
+  apt: 
+    name:
+      - linux-headers-{{ ansible_kernel }}
+      - zfsutils-linux
+      - zfs-dkms
     state: present
+    default_release: "{{ debian_release }}"
 
 - name: debian | enabling zfs module
   modprobe:
     name: zfs
     state: present
 
-- name: debian | installing iscsitarget (if enabled)
+- name: debian | installing open-iscsi (if enabled)
   apt:
     name:
-      - iscsitarget
-      - iscsitarget-dkms
+      - open-iscsi 
     state: present
   when: >
         zfs_enable_iscsi is defined and
         zfs_enable_iscsi
 
-- name: debian | un-installing iscsitarget (if not enabled)
+- name: debian | un-installing open-iscsi (if not enabled)
   apt:
     name:
-      - iscsitarget
-      - iscsitarget-dkms
+      - open-iscsi
     state: absent
   when: >
         zfs_enable_iscsi is defined and


### PR DESCRIPTION
 use debian repository with backports option

Since we have zfs in debian we can use this now.