### PR TITLE
Option install zfs

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,6 +17,10 @@ backports_internal_components: "main contrib non-free"
 backports_internal_additional_packages:
   - apt-transport-https
 
+# Install/Update zfs packates 
+# Set to false to avoid updates on runtime
+zfs_install_update: true
+
 # Defines if ZFS volumes(s) are created
 zfs_create_volumes: false
 zfs_debian_package_key: http://zfsonlinux.org/4D5843EA.asc

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,6 +4,9 @@
   service:
     name: "iscsitarget"
     state: restarted
+  when: >
+        zfs_enable_iscsi is defined and
+        zfs_enable_iscsi
 
 - name: restart nfs-kernel-server
   service:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,10 +1,15 @@
 ---
 # tasks file for ansible-zfs
+
+- set_fact:
+    zfs_install_update: true
+  when: zfs_install_update is undefined
+
 - include: debian.yml
-  when: ansible_distribution == "Debian"
+  when: ansible_distribution == "Debian" and zfs_install_update == true
 
 - include: ubuntu.yml
-  when: ansible_distribution == "Ubuntu"
+  when: ansible_distribution == "Ubuntu" and zfs_install_update == true
 
 - include: manage_zfs.yml
 

--- a/tasks/manage_zfs.yml
+++ b/tasks/manage_zfs.yml
@@ -34,7 +34,7 @@
         zfs_create_pools and
         (item.type == "basic" and
         item.state == "present") and
-        item.devices[0] not in zpool_devices.stdout and
+        (item.devices[0]|basename) not in zpool_devices.stdout and
         item.action|lower == "add" and
         (zpool_created.changed or item.name in zpools.stdout)
 
@@ -59,7 +59,7 @@
         zfs_create_pools and
         (item.type != "basic" and
         item.state == "present") and
-        item.devices[0] not in zpool_devices.stdout and
+        (item.devices[0]|basename) not in zpool_devices.stdout and
         item.action|lower == "add" and
         (zpool_created.changed or item.name in zpools.stdout)
 


### PR DESCRIPTION
Make Option to avoid install / update zfs packages on debian/ubuntu

## Description
Just one new configuration option:

`zfs_install_update: true`

A new version of ZFS has to be planned and tested well. Since debian-backports is updated quite often, maybe updates of zfs version is not what you want while you just configure / create new filesystems or pools.

