### PR TITLE
Update include to include_tasks for newer versions of ansible

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,21 +5,21 @@
     zfs_install_update: true
   when: zfs_install_update is undefined
 
-- include: debian.yml
+- include_tasks: debian.yml
   when: ansible_distribution == "Debian" and zfs_install_update == true
 
-- include: ubuntu.yml
+- include_tasks: ubuntu.yml
   when: ansible_distribution == "Ubuntu" and zfs_install_update == true
 
-- include: manage_zfs.yml
+- include_tasks: manage_zfs.yml
 
-- include: samba.yml
+- include_tasks: samba.yml
   when: zfs_enable_samba
 
-- include: tune_zfs.yml
+- include_tasks: tune_zfs.yml
   when: >
         zfs_enable_performance_tuning is defined and
         zfs_enable_performance_tuning
 
-- include: monitoring.yml
+- include_tasks: monitoring.yml
   when: zfs_enable_monitoring


### PR DESCRIPTION
Tested the change successfully with ansible version 2.12.5 using Debian 11.

According to [Ansible docs](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/include_tasks_module.html), the `include_tasks` was added in version 2.4.

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

Resolves the following deprecation warning:
`[DEPRECATION WARNING]: "include" is deprecated, use include_tasks/import_tasks instead. This feature will be removed in version 2.16. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.`

```bash
$ ansible --version
ansible [core 2.12.5]
```

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
