### PR TITLE
Auto-load encryption keys on boot

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,9 @@ zfs_enable_performance_tuning: false
 # Defines if Samba is installed and configured
 zfs_enable_samba: false
 
+# Defines if keys for encrypted filesystems are loaded on boot
+zfs_autoload_encryption_keys: false
+
 # Defines filesystems to manage
 zfs_filesystems: []
   # - name: nfs

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -41,6 +41,9 @@ zfs_enable_performance_tuning: false
 # Defines if Samba is installed and configured
 zfs_enable_samba: false
 
+# Defines if keys for encrypted filesystems are loaded on boot
+zfs_autoload_encryption_keys: false
+
 # Defines filesystems to manage
 zfs_filesystems: []
   # - name: nfs

--- a/tasks/encryption_keys.yml
+++ b/tasks/encryption_keys.yml
@@ -1,0 +1,38 @@
+---
+- name: Encryption | Set default value for zfs_encrypted_pool_or_datasets
+  set_fact:
+    zfs_encrypted_pools: []
+    zfs_encrypted_datasets: []
+
+- name: Encryption | Get encrypted pools
+  set_fact:
+    zfs_encrypted_pools: "{{ zfs_pools | selectattr('options', 'search', 'keylocation') | map(attribute='name') | list }}"
+  when: zfs_create_pools
+
+- name: Encryption | Get encrypted datasets
+  set_fact:
+    zfs_encrypted_pools: "{{ zfs_filesystems | selectattr('keylocation', 'defined') | map('combine', {'combined_key': item.pool ~ '/' ~ item.name}) | map(attribute='combined_key') | list }}"
+  when: zfs_create_filesystems
+
+- name: Encryption | Create key-load service unit file
+  ansible.builtin.template:
+    src: etc/systemd/system/zfs-load-key@.service.j2
+    dest: /etc/systemd/system/zfs-load-key@.service
+    owner: root
+    group: root
+    mode: 0644
+  when: zfs_encrypted_pools or zfs_encrypted_datasets
+
+- name: Encryption | Activate key-load service for encrypted pools
+  ansible.builtin.systemd_service:
+    name: zfs-load-key@{{ item }}
+    enabled: true
+  loop: "{{ zfs_encrypted_pools }}"
+  when: zfs_create_pools
+
+- name: Encryption | Activate key-load service for encrypted datasets
+  ansible.builtin.systemd_service:
+    name: zfs-load-key@{{ item }}
+    enabled: true
+  loop: "{{ zfs_encrypted_datasets }}"
+  when: zfs_create_filesystems

--- a/tasks/encryption_keys.yml
+++ b/tasks/encryption_keys.yml
@@ -1,36 +1,38 @@
 ---
-- name: Encryption | Set default value for zfs_encrypted_pool_or_datasets
-  set_fact:
+- name: Encryption keys | Set default value for zfs_encrypted_pool_or_datasets
+  ansible.builtin.set_fact:
     zfs_encrypted_pools: []
     zfs_encrypted_datasets: []
 
-- name: Encryption | Get encrypted pools
-  set_fact:
+- name: Encryption keys | Get encrypted pools
+  ansible.builtin.set_fact:
     zfs_encrypted_pools: "{{ zfs_pools | selectattr('options', 'search', 'keylocation') | map(attribute='name') | list }}"
   when: zfs_create_pools
 
-- name: Encryption | Get encrypted datasets
-  set_fact:
-    zfs_encrypted_pools: "{{ zfs_filesystems | selectattr('keylocation', 'defined') | map('combine', {'combined_key': item.pool ~ '/' ~ item.name}) | map(attribute='combined_key') | list }}"
+- name: Encryption keys | Get encrypted datasets
+  ansible.builtin.set_fact:
+    zfs_encrypted_pools: >
+      "{{ zfs_filesystems | selectattr('keylocation', 'defined') | map('combine', {'combined_key': item.pool ~ '/' ~ item.name}) |
+      map(attribute='combined_key') | list }}"
   when: zfs_create_filesystems
 
-- name: Encryption | Create key-load service unit file
+- name: Encryption keys | Create key-load service unit file
   ansible.builtin.template:
     src: etc/systemd/system/zfs-load-key@.service.j2
     dest: /etc/systemd/system/zfs-load-key@.service
     owner: root
     group: root
-    mode: 0644
+    mode: "0644"
   when: zfs_encrypted_pools or zfs_encrypted_datasets
 
-- name: Encryption | Activate key-load service for encrypted pools
+- name: Encryption keys | Activate key-load service for encrypted pools
   ansible.builtin.systemd_service:
     name: zfs-load-key@{{ item }}
     enabled: true
   loop: "{{ zfs_encrypted_pools }}"
   when: zfs_create_pools
 
-- name: Encryption | Activate key-load service for encrypted datasets
+- name: Encryption keys | Activate key-load service for encrypted datasets
   ansible.builtin.systemd_service:
     name: zfs-load-key@{{ item }}
     enabled: true

--- a/tasks/encryption_keys.yml
+++ b/tasks/encryption_keys.yml
@@ -1,19 +1,15 @@
 ---
-- name: Encryption keys | Set default value for zfs_encrypted_pool_or_datasets
-  ansible.builtin.set_fact:
-    zfs_encrypted_pools: []
-    zfs_encrypted_datasets: []
-
 - name: Encryption keys | Get encrypted pools
   ansible.builtin.set_fact:
-    zfs_encrypted_pools: "{{ zfs_pools | selectattr('options', 'search', 'keylocation') | map(attribute='name') | list }}"
+    zfs_encrypted_pools: >-
+      {{ zfs_pools | selectattr('options', 'search', 'keylocation') | map(attribute='name') | list }}
   when: zfs_create_pools
 
 - name: Encryption keys | Get encrypted datasets
   ansible.builtin.set_fact:
-    zfs_encrypted_pools: >
-      "{{ zfs_filesystems | selectattr('keylocation', 'defined') | map('combine', {'combined_key': item.pool ~ '/' ~ item.name}) |
-      map(attribute='combined_key') | list }}"
+    zfs_encrypted_datasets: >-
+      {{ zfs_filesystems | selectattr('keylocation', 'defined') | map('combine', {'dataset_name': '{{ pool }}/{{name}}'})
+                         | map(attribute='dataset_name') | list }}
   when: zfs_create_filesystems
 
 - name: Encryption keys | Create key-load service unit file

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,6 +11,12 @@
 - include_tasks: ubuntu.yml
   when: ansible_distribution == "Ubuntu" and zfs_install_update == true
 
+- include_tasks: encryption_keys.yml
+  when: >
+        (zfs_create_pools or
+        zfs_create_filesystems) and
+        zfs_autoload_encryption_keys
+
 - include_tasks: manage_zfs.yml
 
 - include_tasks: samba.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,7 +11,8 @@
 - include_tasks: ubuntu.yml
   when: ansible_distribution == "Ubuntu" and zfs_install_update == true
 
-- include_tasks: encryption_keys.yml
+- name: Encryption keys
+  include_tasks: encryption_keys.yml
   when: >
         (zfs_create_pools or
         zfs_create_filesystems) and

--- a/templates/etc/systemd/system/zfs-load-key@.service.j2
+++ b/templates/etc/systemd/system/zfs-load-key@.service.j2
@@ -1,0 +1,16 @@
+[Unit]
+Description=Load encryption keys for zpool
+Documentation=man:zfs(8)
+DefaultDependencies=no
+After=systemd-udev-settle.service
+After=systemd-remount-fs.service
+After=zfs-import.target
+Before=zfs-mount.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/sbin/zfs load-key %i
+
+[Install]
+WantedBy=zfs-mount.service


### PR DESCRIPTION
## Description

Add an option to auto-load the encryption keys on boot.

## Related Issue
#27 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document (because there is none 😄)
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
