### PR TITLE
Added support for setting zpool properties (e.g. ashift)

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,9 @@ zfs_pools: []
   #     - ata-INTEL_SSDSC2BW240A4_BTDA329505KM2403GN
   #   # Define pool type... | basic (no-raid) | mirror | raidz | raidz2 | raidz3
   #   type: mirror
+  #   properties:
+  #     ashift: 13
+  #     autoexpand: 'on'
   #   state: present
   #   # override global scrub cron job parameters per zpool
   #   scrub_cron:

--- a/tasks/manage_zfs.yml
+++ b/tasks/manage_zfs.yml
@@ -14,7 +14,7 @@
   when: zfs_pools is defined
 
 - name: manage_zfs | creating basic zpool(s)
-  command: "zpool create {{ item.options | join (' ') if item.options is defined else '' }} {{ item.name }} {{ item.devices|join (' ') }}"
+  command: "zpool create {{ item.options | join (' ') if item.options is defined else '' }} {{ item.properties.keys() | map('regex_replace', '^', '-o ') | zip(item.properties.values()) | map('join', '=') | join(' ') if item.properties is defined else '' }} {{ item.name }} {{ item.devices|join (' ') }}"
   register: zpool_created
   with_items: "{{ zfs_pools }}"
   when: >
@@ -27,7 +27,7 @@
         item.action|lower == "create"
 
 - name: manage_zfs | adding basic zpool(s)
-  command: "zpool add {{ item.options | join (' ') if item.options is defined else '' }} {{ item.name }} {{ item.devices|join (' ') }}"
+  command: "zpool add {{ item.options | join (' ') if item.options is defined else '' }} {{ item.properties.keys() | map('regex_replace', '^', '-o ') | zip(item.properties.values()) | map('join', '=') | join(' ') if item.properties is defined else '' }} {{ item.name }} {{ item.devices|join (' ') }}"
   with_items: "{{ zfs_pools }}"
   when: >
         zfs_pools is defined and
@@ -39,7 +39,7 @@
         (zpool_created.changed or item.name in zpools.stdout)
 
 - name: manage_zfs | creating mirror/zraid zpool(s)
-  command: "zpool create {{ item.options | join (' ') if item.options is defined else '' }} {{ item.name }} {{ item.type }} {{ item.devices|join (' ') }}"
+  command: "zpool create {{ item.options | join (' ') if item.options is defined else '' }} {{ item.properties.keys() | map('regex_replace', '^', '-o ') | zip(item.properties.values()) | map('join', '=') | join(' ') if item.properties is defined else '' }} {{ item.name }} {{ item.type }} {{ item.devices|join (' ') }}"
   with_items: "{{ zfs_pools }}"
   register: zpool_created
   when: >
@@ -52,7 +52,7 @@
         item.action|lower == "create"
 
 - name: manage_zfs | adding mirror/zraid zpool(s)
-  command: "zpool add {{ item.options | join (' ') if item.options is defined else '' }} {{ item.name }} {{ item.type }} {{ item.devices|join (' ') }}"
+  command: "zpool add {{ item.options | join (' ') if item.options is defined else '' }} {{ item.properties.keys() | map('regex_replace', '^', '-o ') | zip(item.properties.values()) | map('join', '=') | join(' ') if item.properties is defined else '' }} {{ item.name }} {{ item.type }} {{ item.devices|join (' ') }}"
   with_items: "{{ zfs_pools }}"
   when: >
         zfs_pools is defined and

--- a/tasks/manage_zfs.yml
+++ b/tasks/manage_zfs.yml
@@ -63,7 +63,26 @@
         item.action|lower == "add" and
         (zpool_created.changed or item.name in zpools.stdout)
 
+- name: manage_zfs | gather pool properties
+  command: "zpool get -Hp -o value {{ item.1.key }} {{ item.0.key }}"
+  changed_when: false
+  with_subelements:
+    - "{{ dict(zfs_pools | selectattr('properties', 'defined') | map(attribute='name') | zip(zfs_pools | selectattr('properties', 'defined') | map(attribute='properties') | map('dict2items'))) | dict2items }}"
+    - value
+  register: zpool_properties
+  when: >
+        zfs_pools is defined and
+        zfs_create_pools
+
 - name: manage_zfs | managing pools
+  command: "zpool set {{ item.item.1.key }}={{ item.item.1.value }} {{ item.item.0.key }}"
+  with_items: "{{ zpool_properties.results }}"
+  when: >
+        zfs_pools is defined and
+        zfs_create_pools and
+        item.stdout != (item.item.1.value | string)
+
+- name: manage_zfs | managing pools default filesystem
   zfs:
     name: "{{ item.name }}"
     extra_zfs_properties:


### PR DESCRIPTION
## Description
Added support for easily setting zpool properties (such as `ashift` or `autoexpand`) when creating/adding to pools, and for updating those properties on the pools if changed

## Related Issue
#29

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
