### PR TITLE
Allow optionally importing zpools before creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,9 @@ zfs_create_filesystems: false
 # Defines if ZFS pool(s) are created
 zfs_create_pools: false
 
+# Defines if ZFS pool(s) are imported if pre-existing
+zfs_import_pools: false
+
 # Defines if ZFS volumes(s) are created
 zfs_create_volumes: false
 zfs_debian_package_key: http://zfsonlinux.org/4D5843EA.asc
@@ -200,6 +203,7 @@ zfs_performance_tuning:
 zfs_pools: []
   # - name: SSD-TANK
   #   action: create
+  #   import: force
   #   # atime: on
   #   # on | off (default) | lzjb | gzip | gzip-1 | gzip-2 | gzip-3 | gzip-4 | gzip-5 | gzip-6 | gzip-7 | gzip-8 | gzip-9 | lz4 | zle
   #   compression: lz4

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,6 +7,9 @@ zfs_create_filesystems: false
 # Defines if ZFS pool(s) are created
 zfs_create_pools: false
 
+# Defines if ZFS pool(s) are imported if pre-existing
+zfs_import_pools: false
+
 # Overwrite debian release
 # debian_release:
 debian_use_backports: True

--- a/tasks/manage_zfs.yml
+++ b/tasks/manage_zfs.yml
@@ -13,6 +13,48 @@
   check_mode: no
   when: zfs_pools is defined
 
+- name: manage zfs | checking for unimported zpools
+  shell: "zpool import | grep pool: | awk '{print $2}'"
+  changed_when: false
+  register: zpool_imports
+  check_mode: no
+  when: >
+        zfs_pools is defined and
+        zfs_import_pools
+
+- name: manage zfs | importing zpools
+  command: "zpool import {{ '-f' if item.import == 'force' else '' }} {{ item.name }}"
+  register: zpool_imported
+  with_items: "{{ zfs_pools }}"
+  when: >
+        zfs_pools is defined and
+        zfs_import_pools and
+        item.name not in zpools.stdout and
+        item.name in zpool_imports.stdout and
+        item.state == "present" and
+        item.devices[0] not in zpool_devices.stdout and
+        (item.action|lower == "import" or (item.action|lower == "create" and item.import))
+
+- name: manage zfs | refreshing existing zpool(s)
+  shell: "zpool list | awk 'FNR >1' | awk '{print $1}'"
+  changed_when: false
+  register: zpools
+  check_mode: no
+  when: >
+        zfs_pools is defined and
+        zfs_import_pools and
+        (zpool_imported.results | selectattr('changed') | map(attribute='changed') | length) > 0
+
+- name: manage_zfs | Refreshing ZPool Status
+  shell: zpool status
+  changed_when: false
+  register: zpool_devices
+  check_mode: no
+  when: >
+        zfs_pools is defined and
+        zfs_import_pools and
+        (zpool_imported.results | selectattr('changed') | map(attribute='changed') | length) > 0
+
 - name: manage_zfs | creating basic zpool(s)
   command: "zpool create {{ item.options | join (' ') if item.options is defined else '' }} {{ item.name }} {{ item.devices|join (' ') }}"
   register: zpool_created

--- a/tasks/manage_zfs.yml
+++ b/tasks/manage_zfs.yml
@@ -1,17 +1,21 @@
 ---
-- name: manage_zfs | checking existing zpool(s)
+- name: manage_zfs | checking existing zpool(s) (pre import)
   shell: "zpool list | awk 'FNR >1' | awk '{print $1}'"
   changed_when: false
   register: zpools
   check_mode: no
-  when: zfs_pools is defined
+  when: >
+        zfs_pools is defined and
+        zfs_import_pools
 
-- name: manage_zfs | Gather ZPool Status
+- name: manage_zfs | Gather ZPool Status (pre import)
   shell: zpool status
   changed_when: false
   register: zpool_devices
   check_mode: no
-  when: zfs_pools is defined
+  when: >
+        zfs_pools is defined and
+        zfs_import_pools
 
 - name: manage zfs | checking for unimported zpools
   shell: "zpool import | grep pool: | awk '{print $2}'"
@@ -35,25 +39,19 @@
         item.devices[0] not in zpool_devices.stdout and
         (item.action|lower == "import" or (item.action|lower == "create" and item.import))
 
-- name: manage zfs | refreshing existing zpool(s)
+- name: manage zfs | checking existing zpool(s) (post import)
   shell: "zpool list | awk 'FNR >1' | awk '{print $1}'"
   changed_when: false
   register: zpools
   check_mode: no
-  when: >
-        zfs_pools is defined and
-        zfs_import_pools and
-        (zpool_imported.results | selectattr('changed') | map(attribute='changed') | length) > 0
+  when: zfs_pools is defined
 
-- name: manage_zfs | Refreshing ZPool Status
+- name: manage_zfs | Gather ZPool Status (post import)
   shell: zpool status
   changed_when: false
   register: zpool_devices
   check_mode: no
-  when: >
-        zfs_pools is defined and
-        zfs_import_pools and
-        (zpool_imported.results | selectattr('changed') | map(attribute='changed') | length) > 0
+  when: zfs_pools is defined
 
 - name: manage_zfs | creating basic zpool(s)
   command: "zpool create {{ item.options | join (' ') if item.options is defined else '' }} {{ item.name }} {{ item.devices|join (' ') }}"


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Allows for optionally importing pools prior to pool creation if they exist, or for importing pools instead of pool creation

## Related Issue
#31 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
