### PR TITLE
Fix set permissions failure when filesystem mountpoint is not defined

### DIFF
--- a/tasks/manage_zfs.yml
+++ b/tasks/manage_zfs.yml
@@ -142,7 +142,9 @@
     owner: "{{ item.owner|default(omit) }}"
     group: "{{ item.group|default(omit) }}"
   with_items: "{{ zfs_filesystems }}"
-  when: zfs_manage_filesystem_permissions
+  when: >
+        zfs_manage_filesystem_permissions and
+        item.mountpoint is defined
 
 - name: manage_zfs | configuring iscsi devices
   template:

--- a/tasks/manage_zfs.yml
+++ b/tasks/manage_zfs.yml
@@ -135,16 +135,37 @@
   with_items: "{{ zfs_volumes }}"
   when: zfs_create_volumes
 
-- name: manage_zfs | Setting ZFS Filesystem Permissions
-  file:
-    path: "{{ item.mountpoint }}"
-    mode: "{{ item.mode|default(omit) }}"
-    owner: "{{ item.owner|default(omit) }}"
-    group: "{{ item.group|default(omit) }}"
-  with_items: "{{ zfs_filesystems }}"
-  when: >
-        zfs_manage_filesystem_permissions and
-        item.mountpoint is defined
+- name: manage_zfs | setting ZFS filesystem permissions
+  block:
+    - name: manage_zfs | setting explicit mount ZFS filesystem permissions
+      file:
+        path: "{{ item.mountpoint }}"
+        mode: "{{ item.mode|default(omit) }}"
+        owner: "{{ item.owner|default(omit) }}"
+        group: "{{ item.group|default(omit) }}"
+      with_items: "{{ zfs_filesystems }}"
+      when: item.mountpoint is defined
+    - name: manage_zfs | fetching inherited ZFS filesystem mounts
+      shell: "zfs get -Hp -o value mountpoint {{ item.pool }}/{{ item.name }}"
+      changed_when: false
+      register: zfs_filesystem_mounts
+      with_items: "{{ zfs_filesystems }}"
+      when: item.mountpoint is not defined
+    - name: manage_zfs | setting inherited mount ZFS filesystem permissions
+      file:
+        path: "{{ item.stdout }}"
+        mode: "{{ item.item.mode|default(omit) }}"
+        owner: "{{ item.item.owner|default(omit) }}"
+        group: "{{ item.item.group|default(omit) }}"
+      with_items:
+        - "{{ zfs_filesystem_mounts.results }}"
+      loop_control:
+        label: "{{ item.item }}"
+      when: >
+            zfs_filesystem_mounts and
+            item.stdout is defined and
+            item.stdout
+  when: zfs_manage_filesystem_permissions
 
 - name: manage_zfs | configuring iscsi devices
   template:


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Fixes role failure when one or more filesystem definitions does not have a mountpoint set and mountpoint permissions are being managed

## Related Issue
#33 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
