### PR TITLE
Fix Encryption Key Autoload

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -46,6 +46,7 @@ zfs_enable_samba: false
 
 # Defines if keys for encrypted filesystems are loaded on boot
 zfs_autoload_encryption_keys: false
+zfs_autoload_encryption_script_path: /etc/zfs/zfs-load-key.sh
 
 # Defines filesystems to manage
 zfs_filesystems: []

--- a/files/zfs-load-key.sh
+++ b/files/zfs-load-key.sh
@@ -1,0 +1,4 @@
+#/bin/bash
+
+# Replaces pool-name\filesystem with pool-name/filesystem
+zfs load-key "${1/'\\'/'/'}"

--- a/tasks/encryption_keys.yml
+++ b/tasks/encryption_keys.yml
@@ -7,15 +7,28 @@
 
 - name: Encryption keys | Get encrypted datasets
   ansible.builtin.set_fact:
-    zfs_encrypted_datasets: >-
-      {{ zfs_filesystems | selectattr('keylocation', 'defined') | map('combine', {'dataset_name': '{{ pool }}/{{name}}'})
-                         | map(attribute='dataset_name') | list }}
+    zfs_encrypted_datasets: "{% set output = [] %}\
+        {% for filesystem in zfs_filesystems %}\
+          {% if filesystem.keylocation is defined  %}\
+            {{ output.append(filesystem.pool + '\\\\' + filesystem.name) }}\
+          {% endif %}\
+        {% endfor %}\
+      {{ output }}"
   when: zfs_create_filesystems
 
 - name: Encryption keys | Create key-load service unit file
   ansible.builtin.template:
     src: etc/systemd/system/zfs-load-key@.service.j2
     dest: /etc/systemd/system/zfs-load-key@.service
+    owner: root
+    group: root
+    mode: "0644"
+  when: zfs_encrypted_pools or zfs_encrypted_datasets
+
+- name: Encryption keys | Copy over load-key script
+  ansible.builtin.copy:
+    src: zfs-load-key.sh
+    dest: "{{ zfs_autoload_encryption_script_path }}"
     owner: root
     group: root
     mode: "0644"
@@ -33,4 +46,4 @@
     name: zfs-load-key@{{ item }}
     enabled: true
   loop: "{{ zfs_encrypted_datasets }}"
-  when: zfs_create_filesystems
+  when: zfs_create_filesystems and (zfs_encrypted_datasets|length > 0)

--- a/tasks/encryption_keys.yml
+++ b/tasks/encryption_keys.yml
@@ -2,7 +2,7 @@
 - name: Encryption keys | Get encrypted pools
   ansible.builtin.set_fact:
     zfs_encrypted_pools: >-
-      {{ zfs_pools | selectattr('options', 'search', 'keylocation') | map(attribute='name') | list }}
+      {{ zfs_pools | selectattr('options', 'defined') | selectattr('options', 'search', 'keylocation') | map(attribute='name') | list }}
   when: zfs_create_pools
 
 - name: Encryption keys | Get encrypted datasets
@@ -26,7 +26,7 @@
     name: zfs-load-key@{{ item }}
     enabled: true
   loop: "{{ zfs_encrypted_pools }}"
-  when: zfs_create_pools
+  when: zfs_create_pools and (zfs_encrypted_pools|length > 0)
 
 - name: Encryption keys | Activate key-load service for encrypted datasets
   ansible.builtin.systemd_service:


### PR DESCRIPTION
These changes fix encryption key autoload being **completely broken** for datasets and in several common scenarios.

## Description
When only some pools are encrypted and/or some pool actions don't have an "options" attribute, like in the default examples, the task to get encrypted pools fails because it tries to selectattr options that don't exist.

Autoloading encryption keys on a **filesystem** basis didn't work at all, with multiple issues each of which individually caused complete failure. 

First, the task to get encrypted datasets created a list of entries that literally looked like:
```
[
  "{{ pool }}/{{name}}",
  "{{ pool }}/{{name}}"
]
```
**without** proper variable substitution. It appears this code was only tested on a very simple pool encryption setup.

Once that was fixed the task that enables the systemd-service failed to auto-load the keys because it doesn't account for the fact that `/` is an illegal char in systemd templates. The workaround for this is to use `\\` as the separator with a custom bash script because 
- `\` is a valid systemd char but not a valid zfs pool char (and not `\` because that causes Jinja2 issues).
- This allows pools to have `-` in their name, since if we used systemd-escape it would replace all `-` with `/`

Thus, a string in the format of `pool-name\\filesystem-name` is passed to a script which replaces `\\` with `/` to properly load keys. Backwards compatibility with previous runs of this role are maintained perfectly through this workaround.

Side Note: The reason this is done with a script that needs to be copied to the system and not inline bash in ExecStart is because systemd parses everything before the shell does.


All of these problems (and some edge cases) are fixed with this PR.
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X ] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [X] I have run the pre-merge tests locally and they pass.
- [X] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
